### PR TITLE
victara: Fix local overlay

### DIFF
--- a/products/vanir_victara.mk
+++ b/products/vanir_victara.mk
@@ -11,6 +11,9 @@ TARGET_SCREEN_HEIGHT := 1920
 # Inherit common product files.
 NO_DRM_BLOBS := true
 
+# Overlay
+DEVICE_PACKAGE_OVERLAYS += device/motorola/victara/overlay
+
 # Inherit common vanir stuff
 $(call inherit-product, vendor/vanir/products/common_phones.mk)
 


### PR DESCRIPTION
The overlay is in the lineage.mk, as it is not called, this ends up leaving the build without overlay, causing several issues.